### PR TITLE
Make custom_response a dictionary at the very beginning

### DIFF
--- a/mockintosh/handlers.py
+++ b/mockintosh/handlers.py
@@ -129,23 +129,12 @@ class GenericHandler(tornado.web.RequestHandler):
         return context
 
     def render_template(self):
-        source_text = None
         is_binary = False
-
-        is_response_str = isinstance(self.custom_response, str)
-        is_response_dict = isinstance(self.custom_response, dict)
         template_engine = _detect_engine(self.custom_response, 'response', default=self.definition_engine)
+        source_text = self.custom_response['body'] if 'body' in self.custom_response else None
 
-        if is_response_str:
-            source_text = self.custom_response
-        elif not self.custom_response:
-            source_text = ''
-            is_response_str = True
-        elif is_response_dict and 'body' in self.custom_response:
-            source_text = self.custom_response['body']
-            is_response_str = True
-        else:
-            return ''
+        if source_text is None:
+            return source_text
 
         if len(source_text) > 1 and source_text[0] == '@':
             template_path = self.resolve_relative_path(source_text)
@@ -160,12 +149,9 @@ class GenericHandler(tornado.web.RequestHandler):
                 except UnicodeDecodeError:
                     is_binary = True
                     logging.debug('Template file is binary. Templating disabled.')
-            is_response_str = False
 
         compiled = None
-        if is_binary or (is_response_dict and (
-            'useTemplating' in self.custom_response and self.custom_response['useTemplating'] is False
-        )):
+        if is_binary or 'useTemplating' in self.custom_response and self.custom_response['useTemplating'] is False:
             compiled = source_text
         else:
             if template_engine == PYBARS:
@@ -255,7 +241,7 @@ class GenericHandler(tornado.web.RequestHandler):
 
     def determine_status_code(self):
         status_code = None
-        if isinstance(self.custom_response, dict) and 'status' in self.custom_response:
+        if 'status' in self.custom_response:
             if isinstance(self.custom_response['status'], str):
                 renderer = TemplateRenderer(
                     self.definition_engine,
@@ -304,7 +290,7 @@ class GenericHandler(tornado.web.RequestHandler):
             for key, value in self.globals['headers'].items():
                 self.set_header(key, value)
 
-        if not isinstance(self.custom_response, dict) or 'headers' not in self.custom_response:
+        if 'headers' not in self.custom_response:
             return
 
         for key, value in self.custom_response['headers'].items():
@@ -421,7 +407,9 @@ class GenericHandler(tornado.web.RequestHandler):
                 self.set_cors_headers()
 
             _id = alternative['id']
-            response = alternative['response']
+            response = alternative['response'] if isinstance(alternative['response'], dict) else {
+                'body': alternative['response']
+            }
             params = alternative['params']
             context = alternative['context']
             return _id, response, params, context
@@ -443,13 +431,7 @@ class GenericHandler(tornado.web.RequestHandler):
         super().finish(chunk)
 
     def should_write(self):
-        return not hasattr(self, 'custom_response') or (
-            (
-                isinstance(self.custom_response, dict) and 'body' in self.custom_response
-            ) or (
-                isinstance(self.custom_response, str)
-            )
-        )
+        return not hasattr(self, 'custom_response') or 'body' in self.custom_response
 
     def decoder(self, string):
         try:

--- a/mockintosh/methods.py
+++ b/mockintosh/methods.py
@@ -26,7 +26,7 @@ def _to_camel_case(snake_case):
 
 def _detect_engine(data, context='config', default=PYBARS):
     template_engine = default
-    if isinstance(data, dict) and 'templatingEngine' in data and (
+    if 'templatingEngine' in data and (
         data['templatingEngine'].lower() in (JINJA.lower(), SHORT_JINJA)
     ):
         template_engine = JINJA

--- a/mockintosh/methods.py
+++ b/mockintosh/methods.py
@@ -26,7 +26,7 @@ def _to_camel_case(snake_case):
 
 def _detect_engine(data, context='config', default=PYBARS):
     template_engine = default
-    if 'templatingEngine' in data and (
+    if isinstance(data, dict) and 'templatingEngine' in data and (
         data['templatingEngine'].lower() in (JINJA.lower(), SHORT_JINJA)
     ):
         template_engine = JINJA


### PR DESCRIPTION
This PR aims to prevent weird `500`s that can possibly happen when strings like `body`, `useTemplating` and `templatingEngine` are present in `self.custom_response` while it's not being a dictionary data type.