### PR TITLE
Fix the issue in `forbid_comma_in_tag` method

### DIFF
--- a/mockintosh/config.py
+++ b/mockintosh/config.py
@@ -57,6 +57,8 @@ class ConfigContainsTag:
                 return
             elif isinstance(row, dict):
                 for key, value in row.items():
+                    if key != 'tag':
+                        continue
                     if ',' in value:  # pragma: no cover
                         raise CommaInTagIsForbidden(value)
             else:


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/up9inc/mockintosh/pull/117

Fixes the error:

```text
[2021-05-23 02:32:18,189 root INFO] Mockintosh v0.9 is starting...
[2021-05-23 02:32:18,190 root INFO] Reading configuration file from path: 05.yaml
[2021-05-23 02:32:18,191 root INFO] Configuration file is a valid YAML file.
[2021-05-23 02:32:18,194 root INFO] Configuration file is valid according to the JSON schema.
[2021-05-23 02:32:18,194 root ERROR] Mock server loading error:
Traceback (most recent call last):
  File "/home/mertyildiran/Documents/mockintosh/mockintosh/__init__.py", line 89, in run
    definition = Definition(source, schema, queue, is_file=is_file)
  File "/home/mertyildiran/Documents/mockintosh/mockintosh/definition.py", line 92, in __init__
    self.services, self.config_root = self.analyze(self.data)
  File "/home/mertyildiran/Documents/mockintosh/mockintosh/definition.py", line 119, in analyze
    config_root = config_root_builder.build(data)
  File "/home/mertyildiran/Documents/mockintosh/mockintosh/builders.py", line 278, in build
    return self.build_config_root(data)
  File "/home/mertyildiran/Documents/mockintosh/mockintosh/builders.py", line 258, in build_config_root
    config_services.append(self.build_config_service(service))
  File "/home/mertyildiran/Documents/mockintosh/mockintosh/builders.py", line 251, in build_config_service
    return self.build_config_http_service(service, internal_service_id)
  File "/home/mertyildiran/Documents/mockintosh/mockintosh/builders.py", line 213, in build_config_http_service
    endpoints=[self.build_config_endpoint(endpoint) for endpoint in service.get('endpoints', [])],
  File "/home/mertyildiran/Documents/mockintosh/mockintosh/builders.py", line 213, in <listcomp>
    endpoints=[self.build_config_endpoint(endpoint) for endpoint in service.get('endpoints', [])],
  File "/home/mertyildiran/Documents/mockintosh/mockintosh/builders.py", line 196, in build_config_endpoint
    dataset=self.build_config_dataset(endpoint.get('dataset', None)),
  File "/home/mertyildiran/Documents/mockintosh/mockintosh/builders.py", line 55, in build_config_dataset
    return ConfigDataset(payload)
  File "/home/mertyildiran/Documents/mockintosh/mockintosh/config.py", line 81, in __init__
    self.forbid_comma_in_tag(self.payload)
  File "/home/mertyildiran/Documents/mockintosh/mockintosh/config.py", line 60, in forbid_comma_in_tag
    if ',' in value:  # pragma: no cover
TypeError: argument of type 'int' is not iterable
```

when a config like this is used:

```yaml
services:
  - port: 8081
    endpoints:
      - path: "/example"
        dataset:
          - var: 5
          - var: 3.14
          - var: "\"hello world\""
        response:
          headers:
            Content-Type: "application/json; charset=UTF-8"
          body: '{"var": {{var}}}'
```