### PR TITLE
Fix the syntax highlighting related to template files in the management UI

### DIFF
--- a/mockintosh/res/management.html
+++ b/mockintosh/res/management.html
@@ -463,6 +463,8 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.23.5/swagger-ui-bundle.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.23.5/swagger-ui-standalone-preset.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.6.0/highlight.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.6.0/languages/django.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.6.0/languages/handlebars.min.js"></script>
 
 <script type="module">
     import {CodeJar} from 'https://medv.io/codejar/codejar.js';


### PR DESCRIPTION
This PR fixes the syntax highlighting in template files.

From:
![Screenshot from 2021-05-23 23-50-01](https://user-images.githubusercontent.com/2502080/119276118-bd409100-bc21-11eb-82e7-f2d8228cda52.png)

To:
![Screenshot from 2021-05-23 23-50-18](https://user-images.githubusercontent.com/2502080/119276121-c03b8180-bc21-11eb-954c-eb997c2e7208.png)
