### PR TITLE
Fix the CSS issue in the Swagger UI `Try it out` on Mozilla Firefox and possibly on Safari

### DIFF
--- a/mockintosh/res/management.html
+++ b/mockintosh/res/management.html
@@ -88,6 +88,7 @@
         }
 
         .responses-table .col {
+            width: -webkit-fit-content;
             width: -moz-fit-content;
             width: fit-content;
         }

--- a/mockintosh/res/management.html
+++ b/mockintosh/res/management.html
@@ -88,6 +88,7 @@
         }
 
         .responses-table .col {
+            width: -moz-fit-content;
             width: fit-content;
         }
 


### PR DESCRIPTION
This PR fixes the CSS issue in the Swagger UI that happens on Mozilla Firefox and possibly on Safari. It does not fix it for IE 8.

![Screenshot from 2021-05-23 23-42-09](https://user-images.githubusercontent.com/2502080/119276032-2b388880-bc21-11eb-9b4e-433e530854ad.png)
