### PR TITLE
adding fromjson hbs helper method

### DIFF
--- a/docs/Templating.md
+++ b/docs/Templating.md
@@ -215,6 +215,14 @@ Jinja2 usage: `{% raw %}{{ fake.random_letters() | tojson }}{% endraw %}`
 
 Handlebars usage: `{% raw %}{{ tojson ( fake.random_letters ) }}{% endraw %}`
 
+#### fromjson(text) (Handlebars only)
+
+A helper to convert a JSON string to a JSON object.
+
+`{% raw %}{{ fromjson ( '{ "testKey": "testValue" }' ) }}{% endraw %}`
+
+would return `{"testKey": "testValue"}`.
+
 #### array(*args) (Handlebars only)
 
 Provides array support in parameters. `{% raw %}{{ array 'a' 'b' 'c' 'd' 'e' }}{% endraw %}` returns `['a', 'b', 'c', 'd', 'e']`.

--- a/mockintosh/hbs/methods.py
+++ b/mockintosh/hbs/methods.py
@@ -96,6 +96,10 @@ def tojson(this, text):
         .replace(u"'", u'\\u0027')
 
 
+def fromjson(this, text):
+    return json.loads(text)
+
+
 def array(this, *args):
     return [*args]
 

--- a/mockintosh/templating.py
+++ b/mockintosh/templating.py
@@ -18,7 +18,7 @@ from jinja2.exceptions import TemplateSyntaxError, UndefinedError
 from pybars import Compiler, PybarsError
 
 from mockintosh.constants import PYBARS, JINJA, JINJA_VARNAME_DICT, SPECIAL_CONTEXT
-from mockintosh.hbs.methods import HbsFaker, tojson, array, replace
+from mockintosh.hbs.methods import HbsFaker, tojson, fromjson, array, replace
 from mockintosh.helpers import _to_camel_case
 from mockintosh.j2.meta import find_undeclared_variables_in_order
 
@@ -138,6 +138,7 @@ class RenderingTask:
         if engine == PYBARS:
             self.inject_methods += [
                 tojson,
+                fromjson,
                 array,
                 replace
             ]


### PR DESCRIPTION
Added a `fromjson` handlebars method that will take stringified JSON and simply convert it to a JSON object.

This has been useful for our specific use case of mockintosh. We configured a reactive kafka consumer and producer and wanted to only produce a specific key value from the consumed message. 

An example would look like the following in handlebars. This will produce a message that is only the `payload` value in the consumed message.
```
{{ tojson (jsonPath (fromjson consumed.value) '$.payload') }}
```