### PR TITLE
Make a dirty hack to read application/json responses of OpenAPI 3.X schemas.

### DIFF
--- a/mockintosh/transpilers.py
+++ b/mockintosh/transpilers.py
@@ -226,11 +226,9 @@ class OASToConfigTranspiler:
                 'headers': {}
             }
 
-            if content_type is not None:
-                response['headers']['Content-Type'] = content_type
-
-            if 'schema' in _response:
-                ref = self._transpile_schema(_response['schema'])
+            if 'content' in _response:
+                response['headers']['Content-Type'] = 'application/json'  # FIXME: this is a dirty hack for a single case
+                ref = self._transpile_schema(_response['content']['application/json']['schema'])
                 response['body'] = self._transpile_body_json_object(ref, last_path_param_index=last_path_param_index)
 
             if 'headers' in _response:


### PR DESCRIPTION
Hey!

I've found that for OpenAPI schemas v3.X the responses don't get parsed at all, thus making mockintosh almost unusable. I've made up this quick-and-dirty hack and things got better. I don't expect this PR to be merged as is, because, obviously, it will break backwards compatibility with version 2.X aka Swagger. Also the only content-type that is handled now is `application/json`, while OpenAPI 3.X may specify multiple content-types and thus multiple different schemas for responses. Hope someone will be able to make things better.

Cheers.