### PR TITLE
Fix for container image with cloud libraries

### DIFF
--- a/Dockerfile.cloud
+++ b/Dockerfile.cloud
@@ -1,3 +1,7 @@
 FROM up9inc/mockintosh:latest
 
+WORKDIR /usr/src/mockintosh
+
 RUN pip3 install .[cloud]
+
+WORKDIR /tmp


### PR DESCRIPTION
The extended cloud library installation failed due to invalid WORKDIR
The WORKDIR has been reset before and after pip installation