### PR TITLE
add extra_kwargs property

### DIFF
--- a/mockintosh/builders.py
+++ b/mockintosh/builders.py
@@ -144,7 +144,8 @@ class ConfigRootBuilder:
             actors=[],
             name=data.get('name', None),
             ssl=data.get('ssl', False),
-            internal_service_id=internal_service_id
+            internal_service_id=internal_service_id,
+            extra_kwargs=data.get('extra_kwargs', None)
         )
 
         actors = []

--- a/mockintosh/config.py
+++ b/mockintosh/config.py
@@ -229,7 +229,8 @@ class ConfigAsyncService(ConfigService):
         actors: List[ConfigActor] = [],
         name: Union[str, None] = None,
         ssl: bool = False,
-        internal_service_id: Union[int, None] = None
+        internal_service_id: Union[int, None] = None,
+        extra_kwargs: Union[dict, None] = None
     ):
         super().__init__(_type, name, internal_service_id)
         ConfigAsyncService.services.append(self)
@@ -237,6 +238,7 @@ class ConfigAsyncService(ConfigService):
         self.address = address
         self.actors = actors
         self.ssl = ssl
+        self.extra_kwargs = extra_kwargs
 
     def get_hint(self):
         return '%s://%s' % (self.type, self.address) if self.name is None else self.name

--- a/mockintosh/definition.py
+++ b/mockintosh/definition.py
@@ -399,7 +399,8 @@ class Definition:
             name=service.name,
             definition=self,
             _id=service.internal_service_id,
-            ssl=service.ssl
+            ssl=service.ssl,
+            extra_kwargs=service.extra_kwargs
         )
         service._impl = async_service
 

--- a/mockintosh/schema.json
+++ b/mockintosh/schema.json
@@ -26,6 +26,10 @@
             "mqtt"
           ]
         },
+        "extra_kwargs": {
+          "type": "object",
+          "default": {}
+        },
         "actors": {
           "type": "array",
           "items": {

--- a/mockintosh/services/asynchronous/kafka.py
+++ b/mockintosh/services/asynchronous/kafka.py
@@ -103,6 +103,7 @@ class KafkaConsumerGroup(AsyncConsumerGroup):
             'bootstrap.servers': first_actor.service.address,
             'group.id': '0',
             'auto.offset.reset': 'earliest'
+            **first_actor.service.extra_kwargs,
         }
         if first_actor.service.ssl:
             config['security.protocol'] = 'SSL'
@@ -159,7 +160,7 @@ class KafkaProducerPayloadList(AsyncProducerPayloadList):
 class KafkaProducer(AsyncProducer):
 
     def _produce(self, key: str, value: str, headers: dict, payload: AsyncProducerPayload) -> None:
-        config = {'bootstrap.servers': self.actor.service.address}
+        config = {'bootstrap.servers': self.actor.service.address, **self.actor.service.extra_kwargs}
         if self.actor.service.ssl:
             config['security.protocol'] = 'SSL'
         producer = Producer(config)
@@ -190,7 +191,8 @@ class KafkaService(AsyncService):
         name: Union[str, None] = None,
         definition=None,
         _id: Union[int, None] = None,
-        ssl: bool = False
+        ssl: bool = False,
+        extra_kwargs: Union[dict, None] = None
     ):
         super().__init__(
             address,
@@ -200,6 +202,7 @@ class KafkaService(AsyncService):
             ssl=ssl
         )
         self.type = 'kafka'
+        self.extra_kwargs = extra_kwargs or {}
 
 
 def build_single_payload_producer(


### PR DESCRIPTION
This is a POC at this point. requires comunity input.

Adds a new  `extra_kwargs` property to allow passing extra settings to kafka clients.

